### PR TITLE
Fix language selector display after i18n detection

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html>
       <head>
         <DynamicMetadata />
       </head>

--- a/src/components/ui/LanguageSelector.tsx
+++ b/src/components/ui/LanguageSelector.tsx
@@ -2,13 +2,48 @@
 
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
 
 export default function LanguageSelector() {
   const { i18n } = useTranslation();
-  const isEnglish = i18n.language.includes('en');
+  const [isReady, setIsReady] = useState(false);
+  const [currentLanguage, setCurrentLanguage] = useState<string>('en');
+
+  useEffect(() => {
+    const updateLanguage = () => {
+      setCurrentLanguage(i18n.language);
+    };
+
+    if (i18n.isInitialized) {
+      setIsReady(true);
+      updateLanguage();
+    } else {
+      const handleInitialized = () => {
+        setIsReady(true);
+        updateLanguage();
+      };
+      i18n.on('initialized', handleInitialized);
+      i18n.on('languageChanged', updateLanguage);
+      
+      return () => {
+        i18n.off('initialized', handleInitialized);
+        i18n.off('languageChanged', updateLanguage);
+      };
+    }
+  }, [i18n]);
+
+  // Don't render until i18n is ready
+  if (!isReady) {
+    return null;
+  }
+
+  // More robust language detection
+  const isEnglish = currentLanguage.startsWith('en');
+  const isJapanese = currentLanguage.startsWith('ja');
 
   const toggleLanguage = () => {
-    i18n.changeLanguage(isEnglish ? 'ja' : 'en');
+    const newLanguage = isEnglish ? 'ja' : 'en';
+    i18n.changeLanguage(newLanguage);
   };
 
   return (
@@ -24,11 +59,7 @@ export default function LanguageSelector() {
         rotate: { type: 'spring', duration: 0.5 }
       }}
     >
-      <div
-        className="flex items-center text-lg font-bold"
-        // animate={{ rotate: isEnglish ? 0 : 180 }}
-        // transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-      >
+      <div className="flex items-center text-lg font-bold">
         <motion.span
           className={`${isEnglish ? 'text-red-500' : 'text-yellow-400'}`}
           animate={{

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,7 +24,40 @@ i18n
   .init({
     resources,
     fallbackLng: 'en',
-    debug: false, // Set to false for production
+    debug: false, // Disable debug for production
+    detection: {
+      // order and from where user language should be detected
+      order: ['navigator', 'localStorage', 'cookie'],
+      
+      // keys or params to lookup language from
+      lookupQuerystring: 'lng',
+      lookupCookie: 'i18nextLng',
+      lookupLocalStorage: 'i18nextLng',
+      lookupSessionStorage: 'i18nextLng',
+      lookupFromPathIndex: 0,
+      lookupFromSubdomainIndex: 0,
+      
+      // cache user language on
+      caches: ['localStorage', 'cookie'],
+      excludeCacheFor: ['cimode'], // languages to not persist (cookie, localStorage)
+      
+      // optional htmlTag with lang attribute, the default is:
+      htmlTag: document.documentElement,
+      
+      // optional set cookie options, reference:[MDN Set-Cookie docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
+      cookieOptions: { path: '/', sameSite: 'strict' },
+      
+      // convert detected language to supported language
+      convertDetectedLanguage: (lng: string) => {
+        if (lng.startsWith('ja')) {
+          return 'ja';
+        }
+        if (lng.startsWith('en')) {
+          return 'en';
+        }
+        return 'en'; // fallback
+      }
+    },
     interpolation: {
       escapeValue: false // not needed for react as it escapes by default
     }


### PR DESCRIPTION
Fix language selector not updating to detected browser language by improving i18n initialization, detection logic, and removing hardcoded HTML lang attribute.

The language selector was not correctly reflecting the browser's detected language (e.g., Japanese) due to a race condition where the component rendered before i18n was fully initialized. Additionally, the previous language detection logic (`i18n.language.includes('en')`) was not robust enough for specific language codes like 'ja-JP', and a hardcoded `lang="en"` attribute in the HTML interfered with dynamic language setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-4296e08c-8c30-4f55-9254-2b3954dffabc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4296e08c-8c30-4f55-9254-2b3954dffabc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

