### PR TITLE
Remove unused variable in LanguageSelector

### DIFF
--- a/src/components/ui/LanguageSelector.tsx
+++ b/src/components/ui/LanguageSelector.tsx
@@ -39,7 +39,6 @@ export default function LanguageSelector() {
 
   // More robust language detection
   const isEnglish = currentLanguage.startsWith('en');
-  const isJapanese = currentLanguage.startsWith('ja');
 
   const toggleLanguage = () => {
     const newLanguage = isEnglish ? 'ja' : 'en';


### PR DESCRIPTION
Remove unused `isJapanese` variable to resolve a TypeScript linting error.

---
<a href="https://cursor.com/background-agent?bcId=bc-20a76214-2484-4f26-8691-74fe01656d80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20a76214-2484-4f26-8691-74fe01656d80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

